### PR TITLE
Use start_with_request=trigger instead of yes for Xdebug debug mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to reeve are documented here.
 
+## 0.3.4
+
+### Fixed
+- **Xdebug `debug` mode no longer fights itself across vhosts.** The FPM master
+  started every request with `xdebug.start_with_request=yes`, so any request
+  from any vhost — a background AJAX call, another site you had open — raced for
+  the IDE's debug connection. IDEs accept one simultaneous connection by
+  default, so the page you actually wanted to debug would silently never attach.
+  `debug` now uses `trigger`: sessions start on demand, from an IDE debug run
+  configuration, a browser extension, or `?XDEBUG_SESSION=1` on the URL.
+  `profile` mode is unchanged and still profiles every request.
+  (Thanks @ruslanbelziuk.)
+
 ## 0.3.3
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ the thing the old switcher-script approach can't do.
 - **Per-vhost PHP version** — each vhost picks its PHP; versions run side by side.
 - **Per-version PHP tuning** — `memory_limit`, upload sizes, OPcache, FPM pool,
   timezone, and a one-click **Xdebug** toggle (off/debug/profile), all without
-  hand-editing `php.ini`.
+  hand-editing `php.ini`. In `debug` mode Xdebug attaches only to requests
+  carrying `XDEBUG_SESSION`/`XDEBUG_TRIGGER` — set by any IDE debug run
+  configuration or browser extension — so background traffic from your other
+  sites can't steal the IDE's connection slot.
 - **Multiple backends** behind one abstraction: **Caddy**, **Apache**, **nginx**
   (OpenLiteSpeed is wired but unsupported on macOS — see below).
 - **Run several servers at once**, on different ports, managed independently.
@@ -133,7 +136,7 @@ Add a database and a mail catcher, tune PHP, or use a framework preset:
 reeve service add mysql && reeve service start mysql   # MySQL on :3306
 reeve service add mailpit && reeve service start mailpit  # SMTP :1025, UI :8025
 reeve php set 8.3 memory_limit 512M                    # tune php.ini
-reeve php xdebug 8.3 debug                              # one-click Xdebug
+reeve php xdebug 8.3 debug                              # Xdebug, attaches on XDEBUG_SESSION
 reeve vhost add shop.test --root ~/Sites/shop --php 8.3 --server caddy --ssl --preset laravel
 reeve vhost add ui.test --proxy http://localhost:5173 --server caddy --ssl   # reverse proxy
 ```
@@ -258,7 +261,7 @@ minutes, and survives closing/reopening the view.
 | `php cli [ver]` | Switch the terminal `php` (via the `~/.reeve/bin` shim); omit to show current |
 | `php ext add\|remove\|list <ver> [name]` | Manage extensions per version (pecl) |
 | `php settings <ver>` / `php set <ver> <key> <value>` | Show / tune php.ini, OPcache, FPM pool |
-| `php xdebug <ver> off\|debug\|profile` | Toggle Xdebug for a version |
+| `php xdebug <ver> off\|debug\|profile` | Toggle Xdebug for a version (`debug` attaches only to requests carrying `XDEBUG_SESSION`/`XDEBUG_TRIGGER`; `profile` profiles every request) |
 | `server add <backend> [--http N --https N] [--default-site] [--root <dir>] [--preset <fw>]` | Add caddy\|apache\|nginx (optionally a catch-all default site; `--root` overrides its docroot, else the global sites root) |
 | `server start\|stop\|restart\|list\|remove <name>` | Manage a server (independent) |
 | `vhost add <host> --root <dir> --php <ver> --server <name> [--ssl] [--preset <fw>] [--proxy <url>]` | Add a vhost |

--- a/crates/reeve/src/cli.rs
+++ b/crates/reeve/src/cli.rs
@@ -122,7 +122,9 @@ pub enum PhpCommands {
         key: String,
         value: String,
     },
-    /// Toggle Xdebug for a version: off | debug | profile.
+    /// Toggle Xdebug for a version: off | debug | profile. `debug` attaches
+    /// only to requests carrying XDEBUG_SESSION/XDEBUG_TRIGGER; `profile`
+    /// profiles every request.
     Xdebug { version: String, mode: String },
 }
 

--- a/crates/reeve/src/main.rs
+++ b/crates/reeve/src/main.rs
@@ -384,6 +384,12 @@ fn cmd_php(c: PhpCommands) -> Result<()> {
             let mode = state::XdebugMode::from_str(&mode)?;
             ops::set_xdebug(&version, mode)?;
             println!("✓ PHP {version}: Xdebug {} (FPM restarted)", mode.as_str());
+            if mode == state::XdebugMode::Debug {
+                println!(
+                    "  Sessions start on demand: use an IDE debug run configuration, a browser\n  \
+                     extension, or add ?XDEBUG_SESSION=1 to the URL."
+                );
+            }
             Ok(())
         }
     }

--- a/crates/reeve/src/php/mod.rs
+++ b/crates/reeve/src/php/mod.rs
@@ -324,16 +324,19 @@ fn build_fpm_conf(php: &PhpVersion) -> Result<String> {
 fn fpm_define_args(php: &PhpVersion) -> Vec<String> {
     let mut d = Vec::new();
     // Default Xdebug fully off so an installed-but-idle Xdebug stops adding
-    // per-call overhead; when enabled, set the client port and connect only on
-    // an explicit trigger (XDEBUG_SESSION cookie/param) — `yes` would make
-    // every request from every vhost race for the IDE's connection slots.
+    // per-call overhead; when enabled, set the client port and the per-mode
+    // start policy (debug waits for a trigger so vhosts stop racing for the
+    // IDE's connection slot; profile runs on every request).
     d.push("-d".into());
     d.push(format!("xdebug.mode={}", php.xdebug.as_str()));
     if !php.xdebug.is_off() {
         d.push("-d".into());
         d.push(format!("xdebug.client_port={}", php.xdebug_port));
         d.push("-d".into());
-        d.push("xdebug.start_with_request=trigger".into());
+        d.push(format!(
+            "xdebug.start_with_request={}",
+            php.xdebug.start_with_request()
+        ));
     }
     // opcache.enable as a startup define (avoids the per-request warning).
     d.push("-d".into());
@@ -620,7 +623,9 @@ mod tests {
         assert!(conf.contains("pm.max_children = 32"));
         assert!(conf.contains("php_admin_value[memory_limit] = 1G"));
 
-        // Enabling Xdebug adds the port + auto-trigger to the startup defines.
+        // Enabling Xdebug adds the port + start policy to the startup defines.
+        // Debug waits for an XDEBUG_SESSION/XDEBUG_TRIGGER request so other
+        // vhosts stop stealing the IDE's single connection slot.
         php.xdebug = XdebugMode::Debug;
         php.xdebug_port = 9009;
         assert_eq!(
@@ -632,6 +637,23 @@ mod tests {
                 "xdebug.client_port=9009",
                 "-d",
                 "xdebug.start_with_request=trigger",
+                "-d",
+                "opcache.enable=1",
+            ]
+        );
+
+        // Profiling has no such contention and must stay on for every request:
+        // with `trigger` a normal page load writes no cachegrind file at all.
+        php.xdebug = XdebugMode::Profile;
+        assert_eq!(
+            fpm_define_args(&php),
+            vec![
+                "-d",
+                "xdebug.mode=profile",
+                "-d",
+                "xdebug.client_port=9009",
+                "-d",
+                "xdebug.start_with_request=yes",
                 "-d",
                 "opcache.enable=1",
             ]

--- a/crates/reeve/src/php/mod.rs
+++ b/crates/reeve/src/php/mod.rs
@@ -324,14 +324,16 @@ fn build_fpm_conf(php: &PhpVersion) -> Result<String> {
 fn fpm_define_args(php: &PhpVersion) -> Vec<String> {
     let mut d = Vec::new();
     // Default Xdebug fully off so an installed-but-idle Xdebug stops adding
-    // per-call overhead; when enabled, set the client port + auto-trigger too.
+    // per-call overhead; when enabled, set the client port and connect only on
+    // an explicit trigger (XDEBUG_SESSION cookie/param) — `yes` would make
+    // every request from every vhost race for the IDE's connection slots.
     d.push("-d".into());
     d.push(format!("xdebug.mode={}", php.xdebug.as_str()));
     if !php.xdebug.is_off() {
         d.push("-d".into());
         d.push(format!("xdebug.client_port={}", php.xdebug_port));
         d.push("-d".into());
-        d.push("xdebug.start_with_request=yes".into());
+        d.push("xdebug.start_with_request=trigger".into());
     }
     // opcache.enable as a startup define (avoids the per-request warning).
     d.push("-d".into());
@@ -629,7 +631,7 @@ mod tests {
                 "-d",
                 "xdebug.client_port=9009",
                 "-d",
-                "xdebug.start_with_request=yes",
+                "xdebug.start_with_request=trigger",
                 "-d",
                 "opcache.enable=1",
             ]

--- a/crates/reeve/src/state.rs
+++ b/crates/reeve/src/state.rs
@@ -122,6 +122,24 @@ impl XdebugMode {
         }
     }
 
+    /// The value to write for `xdebug.start_with_request`.
+    ///
+    /// Debug waits for an explicit trigger (an `XDEBUG_SESSION` /
+    /// `XDEBUG_TRIGGER` cookie or query param, which IDE debug run
+    /// configurations and browser extensions set for you): IDEs accept one
+    /// simultaneous connection by default, so with `yes` a background request
+    /// from another vhost grabs the slot and the page you actually wanted to
+    /// debug never attaches. Profiling has no such contention, and a profiler
+    /// you have to opt each request into produces no cachegrind files at all
+    /// for a normal page load, so it stays on for every request.
+    pub fn start_with_request(&self) -> &'static str {
+        match self {
+            XdebugMode::Off => "no",
+            XdebugMode::Debug => "trigger",
+            XdebugMode::Profile => "yes",
+        }
+    }
+
     pub fn is_off(&self) -> bool {
         matches!(self, XdebugMode::Off)
     }

--- a/crates/reeve/src/tui/mod.rs
+++ b/crates/reeve/src/tui/mod.rs
@@ -2547,10 +2547,16 @@ fn run_xdebug_suspended(
     );
     let result = ops::set_xdebug(version, mode);
     match &result {
-        Ok(()) => println!(
-            "\n✓ Xdebug {} for PHP {version}. Press any key to return…",
-            mode.as_str()
-        ),
+        Ok(()) => {
+            println!("\n✓ Xdebug {} for PHP {version}.", mode.as_str());
+            if mode == XdebugMode::Debug {
+                println!(
+                    "  Sessions start on demand: use an IDE debug run configuration, a browser\n  \
+                     extension, or add ?XDEBUG_SESSION=1 to the URL."
+                );
+            }
+            println!("\nPress any key to return…");
+        }
         Err(e) => println!("\n✗ {e}\nPress any key to return…"),
     }
     let _ = enable_raw_mode();


### PR DESCRIPTION
## Problem

When Xdebug is enabled (`reeve php xdebug <ver> debug`), the FPM master is started with `-d xdebug.start_with_request=yes`. This makes **every request from every vhost** try to connect to the IDE the moment it starts listening on the debug port.

IDEs like PhpStorm default to a single simultaneous debug connection, so with several local sites open in the browser, a background AJAX call or another vhost's request grabs the slot first. The developer's actual page then silently never attaches — the IDE shows a stuck "running" session that never hits breakpoints, and it looks like Xdebug "doesn't connect" at all.

## Fix

Use `xdebug.start_with_request=trigger` instead. Only requests carrying `XDEBUG_SESSION` / `XDEBUG_TRIGGER` (a cookie or query param, set automatically by IDE debug run configurations and browser debug extensions) start a debug session. This matches Xdebug's own shipped default for debug mode, and background traffic from other vhosts no longer competes for the IDE's connection slots.

Verified locally on macOS (Homebrew httpd + FPM 7.4/8.3, PhpStorm): with `trigger`, debugging via a PHP Web Page run configuration attaches reliably even with multiple vhosts open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)